### PR TITLE
make parser return list of dicts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "BGPKIT Parser Python Binding"
 keywords = ["bgp", "mrt", "parser"]
 repository = "https://github.com/bgpkit/bgpkit-parser-py"
 documentation = "https://docs.rs/bgpkit-parser-py"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 edition = "2021"
 license = "MIT"
@@ -16,9 +16,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 bgpkit-parser = "0.7.2"
-itertools = "0.10.3"
 pyo3 ="0.15.1"
-bzip2="0.4"
+dict_derive = "0.4.0"
 
 [build-dependencies]
 pyo3-build-config = "0.15.1"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,35 @@
 
 Python binding for bgpkit-parser
 
+## Installation
+
+```bash
+python3 -m pip install pybgpkit-parser
+```
+
 ## Develop
 
 `maturin develop` builds local python module and add to the venv.
+
+### Publish for Linux
+
+Install multiple Python interpreters:
+
+```bash
+sudo apt install software-properties-common
+sudo add-apt-repository ppa:deadsnakes/ppa
+```
+
+Build and upload for multiple interpreter versions:
+```bash
+maturin publish --interpreter python3.6 --skip-existing
+maturin publish --interpreter python3.7 --skip-existing
+maturin publish --interpreter python3.8 --skip-existing
+maturin publish --interpreter python3.9 --skip-existing
+```
+
+### Publish for MacOS
+
+```bash
+maturin publish --skip-existing
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["maturin>=0.12,<0.13"]
+build-backend = "maturin"

--- a/test.py
+++ b/test.py
@@ -3,4 +3,4 @@ from pybgpkit_parser import Parser
 parser = Parser(url="https://spaces.bgpkit.org/parser/update-example", filters={"peer_ips": "185.1.8.65, 2001:7f8:73:0:3:fa4:0:1"})
 
 for elem in parser:
-    print(elem.origin_asns)
+    print(elem["origin_asns"])


### PR DESCRIPTION
instead of returning a custom class `Elem`, the parser's parse functions will simply return a list of dict objects, making it simpler to handle in downstream apps.

This PR also includes a number of clean ups and removes some unused dependencies.