### PR TITLE
Fix regressions from 6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 bgpkit-parser = "0.11.1"
 pyo3 = { version = "0.25", features = ["extension-module"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
 
 [build-dependencies]
 pyo3-build-config = "0.25"

--- a/examples/filter_count_print.py
+++ b/examples/filter_count_print.py
@@ -13,8 +13,9 @@ for elem in parser:
     print(elem.as_path)
 
     # Optional fields can be checked for None
-    print(elem.aggr_ip==None)
+    print(elem.aggr_ip is None)
 
     # Print the entire parsed BGP update as a dictionary
-    print(json.dumps(elem.to_dict(), indent=4))
+    print(json.dumps(elem.to_dict()))
+    print(elem)
     break

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,9 @@ use bgpkit_parser::models::*;
 use bgpkit_parser::*;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use serde::Serialize;
 use std::collections::HashMap;
 use std::io::Read;
-use serde::Serialize;
 
 #[pymodule]
 fn pybgpkit_parser(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
@@ -140,7 +140,7 @@ fn pybgpkit_parser(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
             }
             let elem_iter = parser.into_iter();
             Ok(Parser { elem_iter })
-       }
+        }
 
         fn parse_all(&mut self, py: Python) -> PyResult<Vec<Py<Elem>>> {
             let mut elems = vec![];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ fn pybgpkit_parser(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
 
         #[pyo3(name = "__str__")]
         fn str_repr(&self) -> PyResult<String> {
-            Ok(format!("{}", serde_json::to_string(self).unwrap()))
+            Ok(serde_json::to_string(self).unwrap().to_string())
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use std::collections::HashMap;
 use std::io::Read;
+use serde::Serialize;
 
 #[pymodule]
 fn pybgpkit_parser(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
@@ -38,7 +39,7 @@ fn pybgpkit_parser(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     }
 
     #[pyclass]
-    #[derive(Clone, PartialEq)]
+    #[derive(Clone, PartialEq, Serialize)]
     pub struct Elem {
         #[pyo3(get, set)]
         pub timestamp: f64,
@@ -100,6 +101,11 @@ fn pybgpkit_parser(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
         fn __getstate__(&self, py: Python) -> PyObject {
             self.to_dict(py)
         }
+
+        #[pyo3(name = "__str__")]
+        fn str_repr(&self) -> PyResult<String> {
+            Ok(format!("{}", serde_json::to_string(self).unwrap()))
+        }
     }
 
     #[pyclass]
@@ -134,7 +140,7 @@ fn pybgpkit_parser(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
             }
             let elem_iter = parser.into_iter();
             Ok(Parser { elem_iter })
-        }
+       }
 
         fn parse_all(&mut self, py: Python) -> PyResult<Vec<Py<Elem>>> {
             let mut elems = vec![];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ fn pybgpkit_parser(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     #[pymethods]
     impl Parser {
         #[new]
-        #[pyo3(text_signature = "(url, filters, /)")]
+        #[pyo3(signature = (url, filters=None, cache_dir=None))]
         fn new(
             url: String,
             filters: Option<HashMap<String, String>>,


### PR DESCRIPTION
This pull request includes updates to the `pybgpkit-parser` library to enhance serialization capabilities, improve Python code style, and refine method signatures. Key changes include adding `serde` for serialization, modifying Python code for better readability, and updating method definitions to support additional parameters.

### Method Signature Refinements:
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L116-R122): Updated the `Parser` constructor to make `cache_dir`and `filters` as optional parameters.
* 
### Serialization Enhancements:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R20-R21): Added `serde` and `serde_json` dependencies to enable serialization functionality.
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L41-R42): Updated `Elem` struct to derive the `Serialize` trait for JSON serialization.
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R104-R108): Added `str_repr` method to provide a string representation of `Elem` using JSON serialization.

### Python Code Example Improvements:
* [`examples/filter_count_print.py`](diffhunk://#diff-7546d7bf83aab9d58cf7e91aba21453a2d33ecd5b01c1370b5e1c91433ff8ca2L16-R20): Replaced `== None` with `is None` for better Python style and readability. Removed indentation in JSON dumps for compact output.

